### PR TITLE
MapQuest: Add "charset=utf-8" to Content-Type

### DIFF
--- a/src/Geocoding.MapQuest/MapQuestGeocoder.cs
+++ b/src/Geocoding.MapQuest/MapQuestGeocoder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -170,7 +170,7 @@ namespace Geocoding.MapQuest
 					break;
 			}
 			request.Method = f.RequestVerb;
-			request.ContentType = "application/" + f.InputFormat;
+			request.ContentType = "application/" + f.InputFormat + "; charset=utf-8";
 
 			if (Proxy != null)
 				request.Proxy = Proxy;

--- a/test/Geocoding.Tests/AsyncGeocoderTest.cs
+++ b/test/Geocoding.Tests/AsyncGeocoderTest.cs
@@ -70,6 +70,13 @@ namespace Geocoding.Tests
 		}
 
 		[Fact]
+		public async Task CanGeocodeWithUnicodeCharacters()
+		{
+			var addresses = await asyncGeocoder.GeocodeAsync("Étretat, France");
+			Assert.NotEmpty(addresses);
+		}
+
+		[Fact]
 		public async Task CanReverseGeocodeAsync()
 		{
 			var addresses = await asyncGeocoder.ReverseGeocodeAsync(38.8976777, -77.036517);

--- a/test/Geocoding.Tests/GeocoderTest.cs
+++ b/test/Geocoding.Tests/GeocoderTest.cs
@@ -70,6 +70,7 @@ namespace Geocoding.Tests
 		[InlineData("40 1/2 Road")]
 		[InlineData("B's Farm RD")]
 		[InlineData("Wilshire & Bundy Plaza, Los Angeles")]
+		[InlineData("Étretat, France")]
 		public virtual async Task CanGeocodeWithSpecialCharacters(string address)
 		{
 			Address[] addresses = (await geocoder.GeocodeAsync(address)).ToArray();

--- a/test/Geocoding.Tests/MapQuestAsyncGeocoderTest.cs
+++ b/test/Geocoding.Tests/MapQuestAsyncGeocoderTest.cs
@@ -1,0 +1,17 @@
+﻿using Geocoding.MapQuest;
+using Xunit;
+
+namespace Geocoding.Tests
+{
+	[Collection("Settings")]
+	public class MapQuestAsyncGeocoderTest : AsyncGeocoderTest
+	{
+		protected override IGeocoder CreateAsyncGeocoder()
+		{
+			return new MapQuestGeocoder(settings.MapQuestKey)
+			{
+				UseOSM = false
+			};
+		}
+	}
+}


### PR DESCRIPTION
Update tests for unicode, and add Async tests for MapQuest.